### PR TITLE
DNSimple API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Initialize a `Fog::DNS` object using the DNSimple provider.
 
 ```ruby
 dns = Fog::DNS.new({
-  provider:       "DNSimple",
-  dnsimple_email: "YOUR_EMAIL",
-  dnsimple_token: "YOUR_API_V1_TOKEN",
+  provider:         "DNSimple",
+  dnsimple_token:   "YOUR_API_TOKEN",
+  dnsimple_account: "YOUR_ACCOUNT_ID",
 })
 ```
 
@@ -60,18 +60,6 @@ The following configurations are supported:
 dns = Fog::DNS.new({
   # Use dnsimple_url to provide a different base URL, e.g. the Sandbox URL
   dnsimple_url:   "https://api.sandbox.dnsimple.com/",
-
-  # API v1 token-based authentication
-  dnsimple_email: "...",
-  dnsimple_token: "...",
-
-  # API v1 basic-auth
-  dnsimple_email: "...",
-  dnsimple_password: "...",
-
-  # API v1 domain-token authentication
-  dnsimple_domain: "example.com",
-  dnsimple_token: "...",
 })
 ```
 

--- a/lib/fog/bin/dnsimple.rb
+++ b/lib/fog/bin/dnsimple.rb
@@ -13,7 +13,7 @@ class Dnsimple < Fog::Bin
       @@connections ||= Hash.new do |hash, key|
         hash[key] = case key
         when :dns
-          Fog::DNS.new(:provider => 'Dnsimple')
+          Fog::DNS.new(provider: "Dnsimple")
         else
           raise ArgumentError, "Unrecognized service: #{key.inspect}"
         end

--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -41,7 +41,6 @@ module Fog
           @dnsimple_email = options[:dnsimple_email]
           @dnsimple_password  = options[:dnsimple_password]
           @dnsimple_token = options[:dnsimple_token]
-          @dnsimple_domain = options[:dnsimple_domain]
         end
 
         def data
@@ -58,7 +57,6 @@ module Fog
           @dnsimple_email = options[:dnsimple_email]
           @dnsimple_password  = options[:dnsimple_password]
           @dnsimple_token = options[:dnsimple_token]
-          @dnsimple_domain = options[:dnsimple_domain]
 
           if options[:dnsimple_url]
             uri = URI.parse(options[:dnsimple_url])
@@ -74,7 +72,7 @@ module Fog
           host       = options[:host]        || "api.dnsimple.com"
           persistent = options[:persistent]  || false
           port       = options[:port]        || 443
-          scheme     = options[:scheme]      || 'https'
+          scheme     = options[:scheme]      || "https"
           @connection = Fog::Core::Connection.new("#{scheme}://#{host}:#{port}", persistent, connection_options)
         end
 
@@ -89,11 +87,7 @@ module Fog
             key = "#{@dnsimple_email}:#{@dnsimple_password}"
             params[:headers].merge!("Authorization" => "Basic " + Base64.encode64(key).gsub("\n",''))
           elsif(@dnsimple_token)
-            if(@dnsimple_domain)
-              params[:headers].merge!("X-DNSimple-Domain-Token" => @dnsimple_token)
-            else
-              params[:headers].merge!("X-DNSimple-Token" => "#{@dnsimple_email}:#{@dnsimple_token}")
-            end
+            params[:headers].merge!("X-DNSimple-Token" => "#{@dnsimple_email}:#{@dnsimple_token}")
           else
             raise ArgumentError.new("Insufficient credentials to properly authenticate!")
           end
@@ -102,8 +96,8 @@ module Fog
               "Content-Type" => "application/json"
           )
 
-          version = params.delete(:version) || 'v1'
-          params[:path] = File.join('/', version, params[:path])
+          version = params.delete(:version) || "v2"
+          params[:path] = File.join("/", version, params[:path])
 
           response = @connection.request(params)
 

--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -4,7 +4,7 @@ require "fog/json"
 module Fog
   module DNS
     class Dnsimple < Fog::Service
-      recognizes :dnsimple_email, :dnsimple_password, :dnsimple_token, :dnsimple_domain, :dnsimple_url
+      recognizes :dnsimple_token, :dnsimple_url
 
       model_path 'fog/dnsimple/models/dns'
       model       :record
@@ -27,8 +27,8 @@ module Fog
         def self.data
           @data ||= Hash.new do |hash, key|
             hash[key] = {
-                :domains => [],
-                :records => {}
+                domains: [],
+                records: {}
             }
           end
         end
@@ -37,23 +37,21 @@ module Fog
           @data = nil
         end
 
-        def initialize(options={})
-          @dnsimple_email = options[:dnsimple_email]
+        def initialize(options = {})
           @dnsimple_token = options[:dnsimple_token]
         end
 
         def data
-          self.class.data[@dnsimple_email]
+          self.class.data[@dnsimple_token]
         end
 
         def reset_data
-          self.class.data.delete(@dnsimple_email)
+          self.class.data.delete(@dnsimple_token)
         end
       end
 
       class Real
         def initialize(options={})
-          @dnsimple_email = options[:dnsimple_email]
           @dnsimple_token = options[:dnsimple_token]
 
           if options[:dnsimple_url]
@@ -81,8 +79,8 @@ module Fog
         def request(params)
           params[:headers] ||= {}
 
-          if(@dnsimple_token)
-            params[:headers].merge!("X-DNSimple-Token" => "#{@dnsimple_email}:#{@dnsimple_token}")
+          if @dnsimple_token
+            params[:headers].merge!("Authorization" => "Bearer #{@dnsimple_token}")
           else
             raise ArgumentError.new("Insufficient credentials to properly authenticate!")
           end

--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -51,7 +51,7 @@ module Fog
       end
 
       class Real
-        def initialize(options={})
+        def initialize(options = {})
           @dnsimple_token = options[:dnsimple_token]
           @dnsimple_account = options[:dnsimple_account]
 

--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -39,7 +39,6 @@ module Fog
 
         def initialize(options={})
           @dnsimple_email = options[:dnsimple_email]
-          @dnsimple_password  = options[:dnsimple_password]
           @dnsimple_token = options[:dnsimple_token]
         end
 
@@ -55,7 +54,6 @@ module Fog
       class Real
         def initialize(options={})
           @dnsimple_email = options[:dnsimple_email]
-          @dnsimple_password  = options[:dnsimple_password]
           @dnsimple_token = options[:dnsimple_token]
 
           if options[:dnsimple_url]
@@ -83,10 +81,7 @@ module Fog
         def request(params)
           params[:headers] ||= {}
 
-          if(@dnsimple_password)
-            key = "#{@dnsimple_email}:#{@dnsimple_password}"
-            params[:headers].merge!("Authorization" => "Basic " + Base64.encode64(key).gsub("\n",''))
-          elsif(@dnsimple_token)
+          if(@dnsimple_token)
             params[:headers].merge!("X-DNSimple-Token" => "#{@dnsimple_email}:#{@dnsimple_token}")
           else
             raise ArgumentError.new("Insufficient credentials to properly authenticate!")

--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -4,7 +4,7 @@ require "fog/json"
 module Fog
   module DNS
     class Dnsimple < Fog::Service
-      recognizes :dnsimple_token, :dnsimple_url
+      recognizes :dnsimple_token, :dnsimple_account, :dnsimple_url
 
       model_path 'fog/dnsimple/models/dns'
       model       :record
@@ -53,6 +53,7 @@ module Fog
       class Real
         def initialize(options={})
           @dnsimple_token = options[:dnsimple_token]
+          @dnsimple_account = options[:dnsimple_account]
 
           if options[:dnsimple_url]
             uri = URI.parse(options[:dnsimple_url])
@@ -79,7 +80,7 @@ module Fog
         def request(params)
           params[:headers] ||= {}
 
-          if @dnsimple_token
+          if @dnsimple_token && @dnsimple_account
             params[:headers].merge!("Authorization" => "Bearer #{@dnsimple_token}")
           else
             raise ArgumentError.new("Insufficient credentials to properly authenticate!")

--- a/lib/fog/dnsimple/models/dns/record.rb
+++ b/lib/fog/dnsimple/models/dns/record.rb
@@ -6,16 +6,16 @@ module Fog
       class Record < Fog::Model
         identity :id
 
-        attribute :zone_id,     :aliases => "domain_id"
+        attribute :zone_id,     aliases: "domain_id"
         attribute :name
-        attribute :value,       :aliases => "content"
+        attribute :value,       aliases: "content"
         attribute :ttl
-        attribute :priority,    :aliases => "prio"
-        attribute :type,        :aliases => "record_type"
+        attribute :priority
+        attribute :type
         attribute :created_at
         attribute :updated_at
 
-        def initialize(attributes={})
+        def initialize(attributes = {})
           super
         end
 
@@ -31,8 +31,7 @@ module Fog
         def save
           requires :name, :type, :value
           options = {}
-          options[:prio] = priority if priority
-          options[:ttl]  = ttl if ttl
+          options[:ttl] = ttl if ttl
 
           # decide whether its a new record or update of an existing
           if id.nil?
@@ -44,7 +43,7 @@ module Fog
             data = service.update_record(zone.id, id, options)
           end
 
-          merge_attributes(data.body["record"])
+          merge_attributes(data.body["data"])
           true
         end
 

--- a/lib/fog/dnsimple/models/dns/records.rb
+++ b/lib/fog/dnsimple/models/dns/records.rb
@@ -12,13 +12,13 @@ module Fog
         def all
           requires :zone
           clear
-          data = service.list_records(zone.id).body.map {|record| record['record']}
+          data = service.list_records(zone.id).body.map { |record| record["data"] }
           load(data)
         end
 
         def get(record_id)
           requires :zone
-          data = service.get_record(zone.id, record_id).body["record"]
+          data = service.get_record(zone.id, record_id).body["data"]
           new(data)
         rescue Excon::Errors::NotFound
           nil
@@ -26,7 +26,7 @@ module Fog
 
         def new(attributes = {})
           requires :zone
-          super({ :zone => zone }.merge!(attributes))
+          super({ zone: zone }.merge!(attributes))
         end
       end
     end

--- a/lib/fog/dnsimple/models/dns/records.rb
+++ b/lib/fog/dnsimple/models/dns/records.rb
@@ -12,7 +12,7 @@ module Fog
         def all
           requires :zone
           clear
-          data = service.list_records(zone.id).body.map { |record| record["data"] }
+          data = service.list_records(zone.id).body["data"]
           load(data)
         end
 

--- a/lib/fog/dnsimple/models/dns/zone.rb
+++ b/lib/fog/dnsimple/models/dns/zone.rb
@@ -7,7 +7,7 @@ module Fog
       class Zone < Fog::Model
         identity :id
 
-        attribute :domain,     :aliases => 'name'
+        attribute :domain,     aliases: "name"
         attribute :created_at
         attribute :updated_at
 
@@ -36,7 +36,7 @@ module Fog
 
         def save
           requires :domain
-          data = service.create_domain(domain).body["domain"]
+          data = service.create_domain(domain).body["data"]
           merge_attributes(data)
           true
         end

--- a/lib/fog/dnsimple/models/dns/zones.rb
+++ b/lib/fog/dnsimple/models/dns/zones.rb
@@ -9,7 +9,7 @@ module Fog
 
         def all
           clear
-          data = service.list_domains.body.map { |zone| zone["data"] }
+          data = service.list_domains.body["data"]
           load(data)
         end
 

--- a/lib/fog/dnsimple/models/dns/zones.rb
+++ b/lib/fog/dnsimple/models/dns/zones.rb
@@ -9,12 +9,12 @@ module Fog
 
         def all
           clear
-          data = service.list_domains.body.map {|zone| zone['domain']}
+          data = service.list_domains.body.map { |zone| zone["data"] }
           load(data)
         end
 
         def get(zone_id)
-          data = service.get_domain(zone_id).body['domain']
+          data = service.get_domain(zone_id).body["data"]
           new(data)
         rescue Excon::Errors::NotFound
           nil

--- a/lib/fog/dnsimple/requests/dns/create_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/create_domain.rb
@@ -5,45 +5,40 @@ module Fog
         # Create a single domain in DNSimple in your account.
         #
         # ==== Parameters
-        # * name<~String> - domain name to host (ie example.com)
+        # * account_id<~String> - the account the domain belong to
+        # * domain_name<~String> - domain name to host (ie example.com)
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        #     * 'domain'<~Hash> The representation of the domain.
-        def create_domain(name)
+        #     * "data"<~Hash> The representation of the domain.
+        def create_domain(account_id, domain_name)
           body = {
-            "domain" => {
-              "name" => name
-            }
+            "name" => domain_name
           }
 
           request(
-            :body     => Fog::JSON.encode(body),
-            :expects  => 201,
-            :method   => 'POST',
-            :path     => "/domains"
+            body:     Fog::JSON.encode(body),
+            expects:  201,
+            method:   "POST",
+            path:     "/#{account_id}/domains"
           )
         end
       end
 
       class Mock
-        def create_domain(name)
+        def create_domain(account_id, domain_name)
           body = {
-            "domain" =>  {
+            "data" =>  {
               "id"                 => Fog::Mock.random_numbers(1).to_i,
-              "user_id"            => 1,
+              "account_id"         => account_id,
               "registrant_id"      => nil,
-              "name"               => name,
-              "unicode_name"       => name,
+              "name"               => domain_name,
+              "unicode_name"       => domain_name,
               "token"              => "4fIFYWYiJayvL2tkf_mkBkqC4L+4RtYqDA",
               "state"              => "registered",
-              "language"           => nil,
-              "lockable"           => true,
               "auto_renew"         => nil,
-              "whois_protected"    => false,
-              "record_count"       => 0,
-              "service_count"      => 0,
+              "private_whois"     => false,
               "expires_on"         => Date.today + 365,
               "created_at"         => Time.now.iso8601,
               "updated_at"         => Time.now.iso8601,

--- a/lib/fog/dnsimple/requests/dns/create_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/create_domain.rb
@@ -5,14 +5,13 @@ module Fog
         # Create a single domain in DNSimple in your account.
         #
         # ==== Parameters
-        # * account_id<~String> - the account the domain belong to
         # * zone_name<~String> - zone name to host (ie example.com)
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * "data"<~Hash> The representation of the domain.
-        def create_domain(account_id, zone_name)
+        def create_domain(zone_name)
           body = {
             "name" => zone_name
           }
@@ -21,17 +20,17 @@ module Fog
             body:     Fog::JSON.encode(body),
             expects:  201,
             method:   "POST",
-            path:     "/#{account_id}/domains"
+            path:     "/#{@dnsimple_account}/domains"
           )
         end
       end
 
       class Mock
-        def create_domain(account_id, zone_name)
+        def create_domain(zone_name)
           body = {
             "data" =>  {
               "id"                 => Fog::Mock.random_numbers(1).to_i,
-              "account_id"         => account_id,
+              "account_id"         => @dnsimple_account,
               "registrant_id"      => nil,
               "name"               => zone_name,
               "unicode_name"       => zone_name,

--- a/lib/fog/dnsimple/requests/dns/create_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/create_domain.rb
@@ -6,15 +6,15 @@ module Fog
         #
         # ==== Parameters
         # * account_id<~String> - the account the domain belong to
-        # * domain_name<~String> - domain name to host (ie example.com)
+        # * zone_name<~String> - zone name to host (ie example.com)
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * "data"<~Hash> The representation of the domain.
-        def create_domain(account_id, domain_name)
+        def create_domain(account_id, zone_name)
           body = {
-            "name" => domain_name
+            "name" => zone_name
           }
 
           request(
@@ -27,14 +27,14 @@ module Fog
       end
 
       class Mock
-        def create_domain(account_id, domain_name)
+        def create_domain(account_id, zone_name)
           body = {
             "data" =>  {
               "id"                 => Fog::Mock.random_numbers(1).to_i,
               "account_id"         => account_id,
               "registrant_id"      => nil,
-              "name"               => domain_name,
-              "unicode_name"       => domain_name,
+              "name"               => zone_name,
+              "unicode_name"       => zone_name,
               "token"              => "4fIFYWYiJayvL2tkf_mkBkqC4L+4RtYqDA",
               "state"              => "registered",
               "auto_renew"         => nil,

--- a/lib/fog/dnsimple/requests/dns/create_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/create_domain.rb
@@ -28,26 +28,24 @@ module Fog
       class Mock
         def create_domain(zone_name)
           body = {
-            "data" =>  {
-              "id"                 => Fog::Mock.random_numbers(1).to_i,
-              "account_id"         => @dnsimple_account,
-              "registrant_id"      => nil,
-              "name"               => zone_name,
-              "unicode_name"       => zone_name,
-              "token"              => "4fIFYWYiJayvL2tkf_mkBkqC4L+4RtYqDA",
-              "state"              => "registered",
-              "auto_renew"         => nil,
-              "private_whois"     => false,
-              "expires_on"         => Date.today + 365,
-              "created_at"         => Time.now.iso8601,
-              "updated_at"         => Time.now.iso8601,
-            }
+            "id"                 => Fog::Mock.random_numbers(1).to_i,
+            "account_id"         => @dnsimple_account,
+            "registrant_id"      => nil,
+            "name"               => zone_name,
+            "unicode_name"       => zone_name,
+            "token"              => "4fIFYWYiJayvL2tkf_mkBkqC4L+4RtYqDA",
+            "state"              => "registered",
+            "auto_renew"         => nil,
+            "private_whois"     => false,
+            "expires_on"         => Date.today + 365,
+            "created_at"         => Time.now.iso8601,
+            "updated_at"         => Time.now.iso8601,
           }
           self.data[:domains] << body
 
           response = Excon::Response.new
           response.status = 201
-          response.body = body
+          response.body = { "data" => body }
           response
         end
       end

--- a/lib/fog/dnsimple/requests/dns/create_record.rb
+++ b/lib/fog/dnsimple/requests/dns/create_record.rb
@@ -5,7 +5,7 @@ module Fog
         # Create a new host in the specified zone
         #
         # ==== Parameters
-        # * domain<~String> - domain name or numeric ID
+        # * zone_name<~String> - zone name
         # * name<~String>
         # * type<~String>
         # * content<~String>
@@ -17,44 +17,41 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * 'record'<~Hash> The representation of the record.
-        def create_record(domain, name, type, content, options = {})
+        def create_record(account_id, zone_name, name, type, content, options = {})
           body = {
-            "record" => {
-              "name" => name,
-              "record_type" => type,
-              "content" => content
-            }
+            "name" => name,
+            "type" => type,
+            "content" => content
           }
-
-          body["record"].merge!(options)
+          body.merge!(options)
 
           request(
-            :body     => Fog::JSON.encode(body),
-            :expects  => 201,
-            :method   => 'POST',
-            :path     => "/domains/#{domain}/records"
+            body:     Fog::JSON.encode(body),
+            expects:  201,
+            method:   "POST",
+            path:     "/#{account_id}/zones/#{zone_name}/records"
           )
         end
       end
 
       class Mock
-        def create_record(domain, name, type, content, options = {})
+        def create_record(account_id, zone_name, name, type, content, options = {})
           body = {
-            "record" => {
+            "data" => {
               "id" => Fog::Mock.random_numbers(1).to_i,
-              "domain_id" => domain,
+              "domain_id" => 1,
               "name" => name,
               "content" => content,
               "ttl" => 3600,
-              "prio" => nil,
-              "record_type" => type,
-              "system_record" => nil,
+              "priority" => 0,
+              "type" => type,
+              "system_record" => false,
               "created_at" => Time.now.iso8601,
               "updated_at" => Time.now.iso8601,
             }.merge(options)
           }
-          self.data[:records][domain] ||= []
-          self.data[:records][domain] << body
+          self.data[:records][zone_name] ||= []
+          self.data[:records][zone_name] << body
 
           response = Excon::Response.new
           response.status = 201

--- a/lib/fog/dnsimple/requests/dns/create_record.rb
+++ b/lib/fog/dnsimple/requests/dns/create_record.rb
@@ -37,25 +37,23 @@ module Fog
       class Mock
         def create_record(zone_name, name, type, content, options = {})
           body = {
-            "data" => {
-              "id" => Fog::Mock.random_numbers(1).to_i,
-              "domain_id" => 1,
-              "name" => name,
-              "content" => content,
-              "ttl" => 3600,
-              "priority" => 0,
-              "type" => type,
-              "system_record" => false,
-              "created_at" => Time.now.iso8601,
-              "updated_at" => Time.now.iso8601,
-            }.merge(options)
-          }
+            "id" => Fog::Mock.random_numbers(1).to_i,
+            "domain_id" => 1,
+            "name" => name,
+            "content" => content,
+            "ttl" => 3600,
+            "priority" => 0,
+            "type" => type,
+            "system_record" => false,
+            "created_at" => Time.now.iso8601,
+            "updated_at" => Time.now.iso8601,
+          }.merge(options)
           self.data[:records][zone_name] ||= []
           self.data[:records][zone_name] << body
 
           response = Excon::Response.new
           response.status = 201
-          response.body = body
+          response.body = { "data" => body }
           response
         end
       end

--- a/lib/fog/dnsimple/requests/dns/create_record.rb
+++ b/lib/fog/dnsimple/requests/dns/create_record.rb
@@ -17,7 +17,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * 'record'<~Hash> The representation of the record.
-        def create_record(account_id, zone_name, name, type, content, options = {})
+        def create_record(zone_name, name, type, content, options = {})
           body = {
             "name" => name,
             "type" => type,
@@ -29,13 +29,13 @@ module Fog
             body:     Fog::JSON.encode(body),
             expects:  201,
             method:   "POST",
-            path:     "/#{account_id}/zones/#{zone_name}/records"
+            path:     "/#{@dnsimple_account}/zones/#{zone_name}/records"
           )
         end
       end
 
       class Mock
-        def create_record(account_id, zone_name, name, type, content, options = {})
+        def create_record(zone_name, name, type, content, options = {})
           body = {
             "data" => {
               "id" => Fog::Mock.random_numbers(1).to_i,

--- a/lib/fog/dnsimple/requests/dns/delete_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/delete_domain.rb
@@ -12,17 +12,17 @@ module Fog
         # * account_id<~String> - the account the domain belong to
         # * zone_name<~String> - zone name
         #
-        def delete_domain(account_id, zone_name)
+        def delete_domain(zone_name)
           request(
             expects:  204,
             method:   "DELETE",
-            path:     "/#{account_id}/domains/#{zone_name}"
+            path:     "/#{@dnsimple_account}/domains/#{zone_name}"
           )
         end
       end
 
       class Mock
-        def delete_domain(_account_id, zone_name)
+        def delete_domain(zone_name)
           self.data[:records].delete(zone_name)
           self.data[:domains].reject! { |domain| domain["data"]["name"] == zone_name }
 

--- a/lib/fog/dnsimple/requests/dns/delete_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/delete_domain.rb
@@ -10,21 +10,21 @@ module Fog
         #
         # ==== Parameters
         # * account_id<~String> - the account the domain belong to
-        # * domain_id<~String> - domain name or numeric ID
+        # * zone_name<~String> - zone name
         #
-        def delete_domain(account_id, domain_id)
+        def delete_domain(account_id, zone_name)
           request(
             expects:  204,
             method:   "DELETE",
-            path:     "/#{account_id}/domains/#{domain_id}"
+            path:     "/#{account_id}/domains/#{zone_name}"
           )
         end
       end
 
       class Mock
-        def delete_domain(_account_id, domain_id)
-          self.data[:records].delete(domain_id)
-          self.data[:domains].reject! { |domain| domain["data"]["name"] == domain_id }
+        def delete_domain(_account_id, zone_name)
+          self.data[:records].delete(zone_name)
+          self.data[:domains].reject! { |domain| domain["data"]["name"] == zone_name }
 
           response = Excon::Response.new
           response.status = 204

--- a/lib/fog/dnsimple/requests/dns/delete_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/delete_domain.rb
@@ -9,24 +9,25 @@ module Fog
         # DNSimple this will not delete the domain from the registry.
         #
         # ==== Parameters
-        # * domain<~String> - domain name or numeric ID
+        # * account_id<~String> - the account the domain belong to
+        # * domain_id<~String> - domain name or numeric ID
         #
-        def delete_domain(domain)
+        def delete_domain(account_id, domain_id)
           request(
-            :expects  => 200,
-            :method   => 'DELETE',
-            :path     => "/domains/#{domain}"
+            expects:  204,
+            method:   "DELETE",
+            path:     "/#{account_id}/domains/#{domain_id}"
           )
         end
       end
 
       class Mock
-        def delete_domain(name)
-          self.data[:records].delete name
-          self.data[:domains].reject! { |domain| domain["domain"]["name"] == name }
+        def delete_domain(_account_id, domain_id)
+          self.data[:records].delete(domain_id)
+          self.data[:domains].reject! { |domain| domain["data"]["name"] == domain_id }
 
           response = Excon::Response.new
-          response.status = 200
+          response.status = 204
           response
         end
       end

--- a/lib/fog/dnsimple/requests/dns/delete_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/delete_domain.rb
@@ -24,7 +24,7 @@ module Fog
       class Mock
         def delete_domain(zone_name)
           self.data[:records].delete(zone_name)
-          self.data[:domains].reject! { |domain| domain["data"]["name"] == zone_name }
+          self.data[:domains].reject! { |domain| domain["name"] == zone_name }
 
           response = Excon::Response.new
           response.status = 204

--- a/lib/fog/dnsimple/requests/dns/delete_record.rb
+++ b/lib/fog/dnsimple/requests/dns/delete_record.rb
@@ -5,20 +5,21 @@ module Fog
         # Delete the record with the given ID for the given domain.
         #
         # ==== Parameters
-        # * domain<~String> - domain name or numeric ID
+        # * account_id<~String> - the account the domain belongs to
+        # * zone_name<~String> - zone name
         # * record_id<~String>
-        def delete_record(domain, record_id)
+        def delete_record(account_id, zone_name, record_id)
           request(
-            :expects  => 200,
-            :method   => "DELETE",
-            :path     => "/domains/#{domain}/records/#{record_id}"
+            expects:  204,
+            method:   "DELETE",
+            path:     "/#{account_id}/zones/#{zone_name}/records/#{record_id}"
           )
         end
       end
 
       class Mock
-        def delete_record(domain, record_id)
-          self.data[:records][domain].reject! { |record| record["record"]["id"] == record_id }
+        def delete_record(_account_id, zone_name, record_id)
+          self.data[:records][zone_name].reject! { |record| record["data"]["id"] == record_id }
 
           response = Excon::Response.new
           response.status = 200

--- a/lib/fog/dnsimple/requests/dns/delete_record.rb
+++ b/lib/fog/dnsimple/requests/dns/delete_record.rb
@@ -5,20 +5,19 @@ module Fog
         # Delete the record with the given ID for the given domain.
         #
         # ==== Parameters
-        # * account_id<~String> - the account the domain belongs to
         # * zone_name<~String> - zone name
         # * record_id<~String>
-        def delete_record(account_id, zone_name, record_id)
+        def delete_record(zone_name, record_id)
           request(
             expects:  204,
             method:   "DELETE",
-            path:     "/#{account_id}/zones/#{zone_name}/records/#{record_id}"
+            path:     "/#{@dnsimple_account}/zones/#{zone_name}/records/#{record_id}"
           )
         end
       end
 
       class Mock
-        def delete_record(_account_id, zone_name, record_id)
+        def delete_record(zone_name, record_id)
           self.data[:records][zone_name].reject! { |record| record["data"]["id"] == record_id }
 
           response = Excon::Response.new

--- a/lib/fog/dnsimple/requests/dns/delete_record.rb
+++ b/lib/fog/dnsimple/requests/dns/delete_record.rb
@@ -18,10 +18,10 @@ module Fog
 
       class Mock
         def delete_record(zone_name, record_id)
-          self.data[:records][zone_name].reject! { |record| record["data"]["id"] == record_id }
+          self.data[:records][zone_name].reject! { |record| record["id"] == record_id }
 
           response = Excon::Response.new
-          response.status = 200
+          response.status = 204
           response
         end
       end

--- a/lib/fog/dnsimple/requests/dns/get_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/get_domain.rb
@@ -25,12 +25,12 @@ module Fog
       class Mock
         def get_domain(zone_name)
           domain = self.data[:domains].find do |domain|
-            domain["data"]["id"] == zone_name || domain["data"]["name"] == zone_name
+            domain["id"] == zone_name || domain["name"] == zone_name
           end
 
           response = Excon::Response.new
           response.status = 200
-          response.body = domain
+          response.body = { "data" => domain }
           response
         end
       end

--- a/lib/fog/dnsimple/requests/dns/get_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/get_domain.rb
@@ -7,26 +7,26 @@ module Fog
         # itself.
         #
         # ==== Parameters
-        # * account_id<~String> - the account the domain belong to
-        # * domain_id<~String> - domain name or numeric ID
+        # * account_id<~String> - the account the domain belongs to
+        # * zone_name<~String> - zone name
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * "data"<~Hash> The representation of the domain.
-        def get_domain(account_id, domain_id)
+        def get_domain(account_id, zone_name)
           request(
             expects:  200,
             method:   "GET",
-            path:     "/#{account_id}/domains/#{domain_id}"
+            path:     "/#{account_id}/domains/#{zone_name}"
           )
         end
       end
 
       class Mock
-        def get_domain(_account_id, domain_id)
+        def get_domain(_account_id, zone_name)
           domain = self.data[:domains].find do |domain|
-            domain["data"]["id"] == domain_id || domain["data"]["name"] == domain_id
+            domain["data"]["id"] == zone_name || domain["data"]["name"] == zone_name
           end
 
           response = Excon::Response.new

--- a/lib/fog/dnsimple/requests/dns/get_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/get_domain.rb
@@ -7,25 +7,26 @@ module Fog
         # itself.
         #
         # ==== Parameters
-        # * domain<~String> - domain name or numeric ID
+        # * account_id<~String> - the account the domain belong to
+        # * domain_id<~String> - domain name or numeric ID
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        #     * 'domain'<~Hash> The representation of the domain.
-        def get_domain(domain)
+        #     * "data"<~Hash> The representation of the domain.
+        def get_domain(account_id, domain_id)
           request(
-            :expects  => 200,
-            :method   => "GET",
-            :path     => "/domains/#{domain}"
+            expects:  200,
+            method:   "GET",
+            path:     "/#{account_id}/domains/#{domain_id}"
           )
         end
       end
 
       class Mock
-        def get_domain(id)
+        def get_domain(_account_id, domain_id)
           domain = self.data[:domains].find do |domain|
-            domain["domain"]["id"] == id || domain["domain"]["name"] == id
+            domain["data"]["id"] == domain_id || domain["data"]["name"] == domain_id
           end
 
           response = Excon::Response.new

--- a/lib/fog/dnsimple/requests/dns/get_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/get_domain.rb
@@ -7,24 +7,23 @@ module Fog
         # itself.
         #
         # ==== Parameters
-        # * account_id<~String> - the account the domain belongs to
         # * zone_name<~String> - zone name
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * "data"<~Hash> The representation of the domain.
-        def get_domain(account_id, zone_name)
+        def get_domain(zone_name)
           request(
             expects:  200,
             method:   "GET",
-            path:     "/#{account_id}/domains/#{zone_name}"
+            path:     "/#{@dnsimple_account}/domains/#{zone_name}"
           )
         end
       end
 
       class Mock
-        def get_domain(_account_id, zone_name)
+        def get_domain(zone_name)
           domain = self.data[:domains].find do |domain|
             domain["data"]["id"] == zone_name || domain["data"]["name"] == zone_name
           end

--- a/lib/fog/dnsimple/requests/dns/get_record.rb
+++ b/lib/fog/dnsimple/requests/dns/get_record.rb
@@ -27,7 +27,7 @@ module Fog
 
           if self.data[:records].key?(zone_name)
             response.status = 200
-            response.body = self.data[:records][zone_name].find { |record| record["data"]["id"] == record_id }
+            response.body = { "data" => self.data[:records][zone_name].find { |record| record["id"] == record_id }}
 
             if response.body.nil?
               response.status = 404

--- a/lib/fog/dnsimple/requests/dns/get_record.rb
+++ b/lib/fog/dnsimple/requests/dns/get_record.rb
@@ -5,7 +5,6 @@ module Fog
         # Gets record from given domain.
         #
         # ==== Parameters
-        # * account_id<~String> - the account the domain belongs to
         # * zone_name<~String> - zone name
         # * record_id<~String>
         #
@@ -13,17 +12,17 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * "data"<~Hash> The representation of the record.
-        def get_record(account_id, zone_name, record_id)
+        def get_record(zone_name, record_id)
           request(
             expects:  200,
             method:   "GET",
-            path:     "/#{account_id}/zones/#{zone_name}/records/#{record_id}"
+            path:     "/#{@dnsimple_account}/zones/#{zone_name}/records/#{record_id}"
           )
         end
       end
 
       class Mock
-        def get_record(_account_id, zone_name, record_id)
+        def get_record(zone_name, record_id)
           response = Excon::Response.new
 
           if self.data[:records].key?(zone_name)

--- a/lib/fog/dnsimple/requests/dns/get_record.rb
+++ b/lib/fog/dnsimple/requests/dns/get_record.rb
@@ -5,29 +5,30 @@ module Fog
         # Gets record from given domain.
         #
         # ==== Parameters
-        # * domain<~String> - domain name or numeric ID
+        # * account_id<~String> - the account the domain belongs to
+        # * zone_name<~String> - zone name
         # * record_id<~String>
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        #     * 'record'<~Hash> The representation of the record.
-        def get_record(domain, record_id)
+        #     * "data"<~Hash> The representation of the record.
+        def get_record(account_id, zone_name, record_id)
           request(
-            :expects  => 200,
-            :method   => "GET",
-            :path     => "/domains/#{domain}/records/#{record_id}"
+            expects:  200,
+            method:   "GET",
+            path:     "/#{account_id}/zones/#{zone_name}/records/#{record_id}"
           )
         end
       end
 
       class Mock
-        def get_record(domain, record_id)
+        def get_record(_account_id, zone_name, record_id)
           response = Excon::Response.new
 
-          if self.data[:records].key?(domain)
+          if self.data[:records].key?(zone_name)
             response.status = 200
-            response.body = self.data[:records][domain].find { |record| record["record"]["id"] == record_id }
+            response.body = self.data[:records][zone_name].find { |record| record["data"]["id"] == record_id }
 
             if response.body.nil?
               response.status = 404
@@ -38,7 +39,7 @@ module Fog
           else
             response.status = 404
             response.body = {
-              "error" => "Couldn't find Domain with name = #{domain}"
+              "error" => "Couldn't find Domain with name = #{zone_name}"
             }
           end
           response

--- a/lib/fog/dnsimple/requests/dns/list_domains.rb
+++ b/lib/fog/dnsimple/requests/dns/list_domains.rb
@@ -2,8 +2,7 @@ module Fog
   module DNS
     class Dnsimple
       class Real
-        # Get the details for a specific domain in your account. You
-        # may pass either the domain numeric ID or the domain name itself.
+        # Get the list of domains in the account.
         #
         # ==== Parameters
         #

--- a/lib/fog/dnsimple/requests/dns/list_domains.rb
+++ b/lib/fog/dnsimple/requests/dns/list_domains.rb
@@ -5,23 +5,24 @@ module Fog
         # Get the list of domains in the account.
         #
         # ==== Parameters
+        # * account_id<~String> - the account the domains belong to
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * <~Array>:
-        #       * 'domain'<~Hash> The representation of the domain.
-        def list_domains
+        #       * "data"<~Hash> The representation of the domain.
+        def list_domains(account_id)
           request(
-            :expects  => 200,
-            :method   => 'GET',
-            :path     => '/domains'
+            expects:  200,
+            method:   "GET",
+            path:     "/#{account_id}/domains"
           )
         end
       end
 
       class Mock
-        def list_domains
+        def list_domains(_account_id)
           response = Excon::Response.new
           response.status = 200
           response.body = self.data[:domains]

--- a/lib/fog/dnsimple/requests/dns/list_domains.rb
+++ b/lib/fog/dnsimple/requests/dns/list_domains.rb
@@ -5,24 +5,23 @@ module Fog
         # Get the list of domains in the account.
         #
         # ==== Parameters
-        # * account_id<~String> - the account the domains belong to
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * <~Array>:
         #       * "data"<~Hash> The representation of the domain.
-        def list_domains(account_id)
+        def list_domains
           request(
             expects:  200,
             method:   "GET",
-            path:     "/#{account_id}/domains"
+            path:     "/#{@dnsimple_account}/domains"
           )
         end
       end
 
       class Mock
-        def list_domains(_account_id)
+        def list_domains
           response = Excon::Response.new
           response.status = 200
           response.body = self.data[:domains]

--- a/lib/fog/dnsimple/requests/dns/list_domains.rb
+++ b/lib/fog/dnsimple/requests/dns/list_domains.rb
@@ -9,8 +9,8 @@ module Fog
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        #     * <~Array>:
-        #       * "data"<~Hash> The representation of the domain.
+        #     * "data"<~Array>:
+        #       * <~Hash> The representation of the domain.
         def list_domains
           request(
             expects:  200,
@@ -24,7 +24,7 @@ module Fog
         def list_domains
           response = Excon::Response.new
           response.status = 200
-          response.body = self.data[:domains]
+          response.body = { "data" => self.data[:domains] }
           response
         end
       end

--- a/lib/fog/dnsimple/requests/dns/list_records.rb
+++ b/lib/fog/dnsimple/requests/dns/list_records.rb
@@ -5,7 +5,6 @@ module Fog
         # Get the list of records for the specific domain.
         #
         # ==== Parameters
-        # * account_id<~String> - the account the domain belongs to
         # * zone_name<~String> - zone name
         #
         # ==== Returns
@@ -13,17 +12,17 @@ module Fog
         #   * body<~Hash>:
         #     * <~Array>:
         #       * "data"<~Hash> The representation of the record.
-        def list_records(account_id, zone_name)
+        def list_records(zone_name)
           request(
             expects:  200,
             method:   "GET",
-            path:     "/#{account_id}/zones/#{zone_name}/records"
+            path:     "/#{@dnsimple_account}/zones/#{zone_name}/records"
           )
         end
       end
 
       class Mock
-        def list_records(_account_id, zone_name)
+        def list_records(zone_name)
           response = Excon::Response.new
           response.status = 200
           response.body = self.data[:records][zone_name] || []

--- a/lib/fog/dnsimple/requests/dns/list_records.rb
+++ b/lib/fog/dnsimple/requests/dns/list_records.rb
@@ -5,27 +5,28 @@ module Fog
         # Get the list of records for the specific domain.
         #
         # ==== Parameters
-        # * domain<~String> - domain name or numeric ID
+        # * account_id<~String> - the account the domain belongs to
+        # * zone_name<~String> - zone name
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * <~Array>:
-        #       * 'record'<~Hash> The representation of the record.
-        def list_records(domain)
+        #       * "data"<~Hash> The representation of the record.
+        def list_records(account_id, zone_name)
           request(
-            :expects  => 200,
-            :method   => "GET",
-            :path     => "/domains/#{domain}/records"
+            expects:  200,
+            method:   "GET",
+            path:     "/#{account_id}/zones/#{zone_name}/records"
           )
         end
       end
 
       class Mock
-        def list_records(domain)
+        def list_records(_account_id, zone_name)
           response = Excon::Response.new
           response.status = 200
-          response.body = self.data[:records][domain] || []
+          response.body = self.data[:records][zone_name] || []
           response
         end
       end

--- a/lib/fog/dnsimple/requests/dns/list_records.rb
+++ b/lib/fog/dnsimple/requests/dns/list_records.rb
@@ -10,8 +10,8 @@ module Fog
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        #     * <~Array>:
-        #       * "data"<~Hash> The representation of the record.
+        #     * "data"<~Array>:
+        #       * <~Hash> The representation of the record.
         def list_records(zone_name)
           request(
             expects:  200,
@@ -25,7 +25,7 @@ module Fog
         def list_records(zone_name)
           response = Excon::Response.new
           response.status = 200
-          response.body = self.data[:records][zone_name] || []
+          response.body = { "data" => self.data[:records][zone_name] || [] }
           response
         end
       end

--- a/lib/fog/dnsimple/requests/dns/update_record.rb
+++ b/lib/fog/dnsimple/requests/dns/update_record.rb
@@ -5,7 +5,6 @@ module Fog
         # Update the given record for the given domain.
         #
         # ==== Parameters
-        # * account_id<~String> - the account the domain belongs to
         # * zone_name<~String> - zone name
         # * record_id<~String>
         # * options<~Hash> - optional
@@ -18,20 +17,20 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * "data"<~Hash> The representation of the record.
-        def update_record(account_id, zone_name, record_id, options)
+        def update_record(zone_name, record_id, options)
           body = options
 
           request(
             body:     Fog::JSON.encode(body),
             expects:  200,
             method:   "PUT",
-            path:     "/#{account_id}/zones/#{zone_name}/records/#{record_id}"
+            path:     "/#{@dnsimple_account}/zones/#{zone_name}/records/#{record_id}"
           )
         end
       end
 
       class Mock
-        def update_record(_account_id, zone_name, record_id, options)
+        def update_record(zone_name, record_id, options)
           record = self.data[:records][zone_name].find { |record| record["data"]["id"] == record_id }
           response = Excon::Response.new
 

--- a/lib/fog/dnsimple/requests/dns/update_record.rb
+++ b/lib/fog/dnsimple/requests/dns/update_record.rb
@@ -5,7 +5,8 @@ module Fog
         # Update the given record for the given domain.
         #
         # ==== Parameters
-        # * domain<~String> - domain name or numeric ID
+        # * account_id<~String> - the account the domain belongs to
+        # * zone_name<~String> - zone name
         # * record_id<~String>
         # * options<~Hash> - optional
         #   * type<~String>
@@ -16,32 +17,30 @@ module Fog
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        #     * 'record'<~Hash> The representation of the record.
-        def update_record(domain, record_id, options)
-          body = {
-            "record" => options
-          }
+        #     * "data"<~Hash> The representation of the record.
+        def update_record(account_id, zone_name, record_id, options)
+          body = options
 
           request(
-            :body     => Fog::JSON.encode(body),
-            :expects  => 200,
-            :method   => "PUT",
-            :path     => "/domains/#{domain}/records/#{record_id}"
+            body:     Fog::JSON.encode(body),
+            expects:  200,
+            method:   "PUT",
+            path:     "/#{account_id}/zones/#{zone_name}/records/#{record_id}"
           )
         end
       end
 
       class Mock
-        def update_record(domain, record_id, options)
-          record = self.data[:records][domain].find { |record| record["record"]["id"] == record_id }
+        def update_record(_account_id, zone_name, record_id, options)
+          record = self.data[:records][zone_name].find { |record| record["data"]["id"] == record_id }
           response = Excon::Response.new
 
           if record.nil?
             response.status = 400
           else
             response.status = 200
-            record["record"].merge!(options)
-            record["record"]["updated_at"] = Time.now.iso8601
+            record["data"].merge!(options)
+            record["data"]["updated_at"] = Time.now.iso8601
             response.body = record
           end
 

--- a/lib/fog/dnsimple/requests/dns/update_record.rb
+++ b/lib/fog/dnsimple/requests/dns/update_record.rb
@@ -23,7 +23,7 @@ module Fog
           request(
             body:     Fog::JSON.encode(body),
             expects:  200,
-            method:   "PUT",
+            method:   "PATCH",
             path:     "/#{@dnsimple_account}/zones/#{zone_name}/records/#{record_id}"
           )
         end
@@ -31,16 +31,16 @@ module Fog
 
       class Mock
         def update_record(zone_name, record_id, options)
-          record = self.data[:records][zone_name].find { |record| record["data"]["id"] == record_id }
+          record = self.data[:records][zone_name].find { |record| record["id"] == record_id }
           response = Excon::Response.new
 
           if record.nil?
             response.status = 400
           else
             response.status = 200
-            record["data"].merge!(options)
-            record["data"]["updated_at"] = Time.now.iso8601
-            response.body = record
+            record.merge!(options)
+            record["updated_at"] = Time.now.iso8601
+            response.body = { "data" => record }
           end
 
           response

--- a/lib/fog/dnsimple/version.rb
+++ b/lib/fog/dnsimple/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Dnsimple
-    VERSION = "1.0.0"
+    VERSION = "2.0.0"
   end
 end

--- a/lib/fog/dnsimple/version.rb
+++ b/lib/fog/dnsimple/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Dnsimple
-    VERSION = "2.0.0"
+    VERSION = "1.0.0"
   end
 end

--- a/tests/requests/dns/dns_tests.rb
+++ b/tests/requests/dns/dns_tests.rb
@@ -6,7 +6,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
   tests("success") do
 
     test("get current domain count") do
-      response = Fog::DNS[:dnsimple].list_domains()
+      response = Fog::DNS[:dnsimple].list_domains(0)
       if response.status == 200
         @domain_count = response.body.size
       end
@@ -34,10 +34,10 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       name = "www"
       type = "A"
       content = "1.2.3.4"
-      response = Fog::DNS[:dnsimple].create_record(domain, name, type, content)
+      response = Fog::DNS[:dnsimple].create_record(0, domain, name, type, content)
 
       if response.status == 201
-        @record = response.body["record"]
+        @record = response.body["data"]
       end
 
       response.status == 201
@@ -49,19 +49,19 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       name = ""
       type = "MX"
       content = "mail.#{domain}"
-      options = { "ttl" => 60, "prio" => 10 }
-      response = Fog::DNS[:dnsimple].create_record(domain, name, type, content, options)
+      options = { "ttl" => 60, "priority" => 10 }
+      response = Fog::DNS[:dnsimple].create_record(0, domain, name, type, content, options)
 
       test "MX record creation returns 201" do
         response.status == 201
       end
 
       options.each do |key, value|
-        test("MX record has option #{key}") { value == response.body["record"][key.to_s] }
+        test("MX record has option #{key}") { value == response.body["data"][key.to_s] }
       end
 
       test "MX record is correct type" do
-        response.body["record"]["record_type"] == "MX"
+        response.body["data"]["type"] == "MX"
       end
     end
 
@@ -69,28 +69,28 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       domain = @domain["name"]
       record_id = @record["id"]
 
-      response = Fog::DNS[:dnsimple].get_record(domain, record_id)
+      response = Fog::DNS[:dnsimple].get_record(0, domain, record_id)
 
-      (response.status == 200) and (@record == response.body["record"])
+      (response.status == 200) and (@record == response.body["data"])
     end
 
     test("update a record") do
       domain = @domain["name"]
       record_id = @record["id"]
       options = { "content" => "2.3.4.5", "ttl" => 600 }
-      response = Fog::DNS[:dnsimple].update_record(domain, record_id, options)
+      response = Fog::DNS[:dnsimple].update_record(0, domain, record_id, options)
       response.status == 200
     end
 
     test("list records") do
-      response = Fog::DNS[:dnsimple].list_records(@domain["name"])
+      response = Fog::DNS[:dnsimple].list_records(0, @domain["name"])
 
       if response.status == 200
         @records = response.body
       end
 
       test "list records returns all records for domain" do
-        @records.reject { |record| record["record"]["system_record"] }.size == 2
+        @records.reject { |record| record["data"]["system_record"] }.size == 2
       end
 
       response.status == 200
@@ -101,8 +101,8 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
 
       result = true
       @records.each do |record|
-        next if record["record"]["system_record"]
-        response = Fog::DNS[:dnsimple].delete_record(domain, record["record"]["id"])
+        next if record["data"]["system_record"]
+        response = Fog::DNS[:dnsimple].delete_record(0, domain, record["data"]["id"])
         if response.status != 200
           result = false
           break

--- a/tests/requests/dns/dns_tests.rb
+++ b/tests/requests/dns/dns_tests.rb
@@ -6,7 +6,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
   tests("success") do
 
     test("get current domain count") do
-      response = Fog::DNS[:dnsimple].list_domains(0)
+      response = Fog::DNS[:dnsimple].list_domains
       if response.status == 200
         @domain_count = response.body.size
       end
@@ -16,7 +16,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
 
     test("create domain") do
       domain = generate_unique_domain
-      response = Fog::DNS[:dnsimple].create_domain(0, domain)
+      response = Fog::DNS[:dnsimple].create_domain(domain)
       if response.status == 201
         @domain = response.body["data"]
       end
@@ -25,7 +25,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
     end
 
     test("get domain by id") do
-      response = Fog::DNS[:dnsimple].get_domain(0, @domain["id"])
+      response = Fog::DNS[:dnsimple].get_domain(@domain["id"])
       response.status == 200
     end
 
@@ -34,7 +34,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       name = "www"
       type = "A"
       content = "1.2.3.4"
-      response = Fog::DNS[:dnsimple].create_record(0, domain, name, type, content)
+      response = Fog::DNS[:dnsimple].create_record(domain, name, type, content)
 
       if response.status == 201
         @record = response.body["data"]
@@ -50,7 +50,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       type = "MX"
       content = "mail.#{domain}"
       options = { "ttl" => 60, "priority" => 10 }
-      response = Fog::DNS[:dnsimple].create_record(0, domain, name, type, content, options)
+      response = Fog::DNS[:dnsimple].create_record(domain, name, type, content, options)
 
       test "MX record creation returns 201" do
         response.status == 201
@@ -69,7 +69,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       domain = @domain["name"]
       record_id = @record["id"]
 
-      response = Fog::DNS[:dnsimple].get_record(0, domain, record_id)
+      response = Fog::DNS[:dnsimple].get_record(domain, record_id)
 
       (response.status == 200) and (@record == response.body["data"])
     end
@@ -78,12 +78,12 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       domain = @domain["name"]
       record_id = @record["id"]
       options = { "content" => "2.3.4.5", "ttl" => 600 }
-      response = Fog::DNS[:dnsimple].update_record(0, domain, record_id, options)
+      response = Fog::DNS[:dnsimple].update_record(domain, record_id, options)
       response.status == 200
     end
 
     test("list records") do
-      response = Fog::DNS[:dnsimple].list_records(0, @domain["name"])
+      response = Fog::DNS[:dnsimple].list_records(@domain["name"])
 
       if response.status == 200
         @records = response.body
@@ -102,7 +102,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       result = true
       @records.each do |record|
         next if record["data"]["system_record"]
-        response = Fog::DNS[:dnsimple].delete_record(0, domain, record["data"]["id"])
+        response = Fog::DNS[:dnsimple].delete_record(domain, record["data"]["id"])
         if response.status != 200
           result = false
           break
@@ -113,7 +113,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
     end
 
     test("delete domain") do
-      response = Fog::DNS[:dnsimple].delete_domain(0, @domain["name"])
+      response = Fog::DNS[:dnsimple].delete_domain(@domain["name"])
       response.status == 204
     end
 

--- a/tests/requests/dns/dns_tests.rb
+++ b/tests/requests/dns/dns_tests.rb
@@ -16,16 +16,16 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
 
     test("create domain") do
       domain = generate_unique_domain
-      response = Fog::DNS[:dnsimple].create_domain(domain)
+      response = Fog::DNS[:dnsimple].create_domain(0, domain)
       if response.status == 201
-        @domain = response.body["domain"]
+        @domain = response.body["data"]
       end
 
       response.status == 201
     end
 
     test("get domain by id") do
-      response = Fog::DNS[:dnsimple].get_domain(@domain["id"])
+      response = Fog::DNS[:dnsimple].get_domain(0, @domain["id"])
       response.status == 200
     end
 
@@ -113,8 +113,8 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
     end
 
     test("delete domain") do
-      response = Fog::DNS[:dnsimple].delete_domain(@domain["name"])
-      response.status == 200
+      response = Fog::DNS[:dnsimple].delete_domain(0, @domain["name"])
+      response.status == 204
     end
 
   end

--- a/tests/requests/dns/dns_tests.rb
+++ b/tests/requests/dns/dns_tests.rb
@@ -8,7 +8,7 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
     test("get current domain count") do
       response = Fog::DNS[:dnsimple].list_domains
       if response.status == 200
-        @domain_count = response.body.size
+        @domain_count = response.body["data"].size
       end
 
       response.status == 200
@@ -86,11 +86,11 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
       response = Fog::DNS[:dnsimple].list_records(@domain["name"])
 
       if response.status == 200
-        @records = response.body
+        @records = response.body["data"]
       end
 
       test "list records returns all records for domain" do
-        @records.reject { |record| record["data"]["system_record"] }.size == 2
+        @records.reject { |record| record["system_record"] }.size == 2
       end
 
       response.status == 200
@@ -101,9 +101,9 @@ Shindo.tests('Fog::DNS[:dnsimple] | DNS requests', ['dnsimple', 'dns']) do
 
       result = true
       @records.each do |record|
-        next if record["data"]["system_record"]
-        response = Fog::DNS[:dnsimple].delete_record(domain, record["data"]["id"])
-        if response.status != 200
+        next if record["system_record"]
+        response = Fog::DNS[:dnsimple].delete_record(domain, record["id"])
+        if response.status != 204
           result = false
           break
         end


### PR DESCRIPTION
This PR upgrades the `fog-dnsimple` lib to use the DNSimple API v2 instead of the deprecated v1.
v2 were released in December 2016. API v1 are going to be shut down in the upcoming weeks.

Once this PR is merged, I will likely release a major version due to all the changes. API v2 is not backward compatible with API v1.

I tested the changes using the mock adapter

    $ bundle exec shindont

and I also run an integration testing in sandbox:

    $ FOG_RC=~/.fog bundle exec shindont

The `.fog` file contains the sandbox credentials:

```
➜  fog-dnsimple git:(dnsimple-v2) cat ~/.fog
default:
  dnsimple_url:     "https://api.sandbox.dnsimple.com/"
  dnsimple_token:   "xxx"
  dnsimple_account: "000"
```

