### PR TITLE
Add ability to query paginated/all records and domains

### DIFF
--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -14,11 +14,13 @@ module Fog
 
       request_path 'fog/dnsimple/requests/dns'
       request :list_domains
+      request :list_all_domains
       request :create_domain
       request :get_domain
       request :delete_domain
       request :create_record
       request :list_records
+      request :list_all_records
       request :update_record
       request :delete_record
       request :get_record
@@ -98,6 +100,32 @@ module Fog
           unless response.body.empty?
             response.body = Fog::JSON.decode(response.body)
           end
+          response
+        end
+
+        private
+
+        def paginate(query: {})
+          current_page = 0
+          total_pages = nil
+          total_entries = nil
+          collection = []
+          response = nil
+
+          begin
+            current_page += 1
+            current_query = query.merge({ page: current_page, per_page: 5 })
+
+            response = yield(current_query)
+            total_entries ||= response.body.dig("pagination", "total_entries")
+            total_pages ||= response.body.dig("pagination", "total_pages")
+            collection.concat(response.body["data"])
+          end while current_page < total_pages
+
+          total_entries == collection.size or
+            raise(Fog::Errors::Error, "Expected `#{total_entries}`, fetched only `#{collection.size}`")
+
+          response.body["data"] = collection
           response
         end
       end

--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -114,7 +114,7 @@ module Fog
 
           begin
             current_page += 1
-            current_query = query.merge({ page: current_page, per_page: 5 })
+            current_query = query.merge({ page: current_page, per_page: 100 })
 
             response = yield(current_query)
             total_entries ||= response.body.dig("pagination", "total_entries")

--- a/lib/fog/dnsimple/requests/dns/list_all_domains.rb
+++ b/lib/fog/dnsimple/requests/dns/list_all_domains.rb
@@ -1,0 +1,38 @@
+module Fog
+  module DNS
+    class Dnsimple
+      class Real
+        # Get the list of ALL domains in the account.
+        #
+        # This method is similar to #list_domains, but instead of returning the results
+        # of a specific page it iterates all the pages and returns the entire collection.
+        #
+        # Please use this method carefully, as fetching the entire collection will increase
+        # the number of requests you send to the API server and you may eventually be rate-limited.
+        #
+        # @see https://developer.dnsimple.com/v2/domains/#list
+        # @see https://github.com/dnsimple/dnsimple-developer/tree/master/fixtures/v2/listDomains
+        #
+        # @param  query [Hash]
+        # @return [Excon::Response]
+        def list_all_domains(query: {})
+          paginate(query: query) do |current_query|
+            list_domains(query: current_query)
+          end
+        end
+      end
+
+      class Mock
+        def list_all_domains(_query: {})
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+              "data" => self.data[:domains],
+              "pagination" => { "current_page" => nil, "per_page" => nil, "total_entries" => 60, "total_pages" => 2 }
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/dnsimple/requests/dns/list_all_records.rb
+++ b/lib/fog/dnsimple/requests/dns/list_all_records.rb
@@ -1,0 +1,39 @@
+module Fog
+  module DNS
+    class Dnsimple
+      class Real
+        # Get the list of ALL records for the specific zone.
+        #
+        # This method is similar to #list_domains, but instead of returning the results
+        # of a specific page it iterates all the pages and returns the entire collection.
+        #
+        # Please use this method carefully, as fetching the entire collection will increase
+        # the number of requests you send to the API server and you may eventually be rate-limited.
+        #
+        # @see https://developer.dnsimple.com/v2/zones/records/#list
+        # @see https://github.com/dnsimple/dnsimple-developer/tree/master/fixtures/v2/listZoneRecords
+        #
+        # @param  zone_name [String]
+        # @param  query [Hash]
+        # @return [Excon::Response]
+        def list_all_records(zone_name, query: {})
+          paginate(query: query) do |current_query|
+            list_records(zone_name, query: current_query)
+          end
+        end
+      end
+
+      class Mock
+        def list_all_records(zone_name, _query: {})
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+              "data" => Array(self.data[:records][zone_name]),
+              "pagination" => { "current_page" => nil, "per_page" => nil, "total_entries" => 60, "total_pages" => 2 }
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/dnsimple/requests/dns/list_domains.rb
+++ b/lib/fog/dnsimple/requests/dns/list_domains.rb
@@ -2,31 +2,33 @@ module Fog
   module DNS
     class Dnsimple
       class Real
-        # Get the list of domains in the account.
+        # Get the paginated list of domains in the account.
         #
-        # ==== Parameters
+        # @see https://developer.dnsimple.com/v2/domains/#list
+        # @see https://github.com/dnsimple/dnsimple-developer/tree/master/fixtures/v2/listDomains
         #
-        # ==== Returns
-        # * response<~Excon::Response>:
-        #   * body<~Hash>:
-        #     * "data"<~Array>:
-        #       * <~Hash> The representation of the domain.
-        def list_domains
+        # @param  query [Hash]
+        # @return [Excon::Response]
+        def list_domains(query: {})
           request(
-            expects:  200,
-            method:   "GET",
-            path:     "/#{@dnsimple_account}/domains"
+            expects: 200,
+            method: "GET",
+            path: "/#{@dnsimple_account}/domains",
+            query: query
           )
         end
       end
 
       class Mock
-        def list_domains
+        def list_domains(query: {})
+          page = query[:page] || 1
+          per_page = query[:per_page] || 30
+
           response = Excon::Response.new
           response.status = 200
           response.body = {
               "data" => self.data[:domains],
-              "pagination" => { "current_page" => 1, "per_page" => 30, "total_entries" => 60, "total_pages" => 2 }
+              "pagination" => { "current_page" => page, "per_page" => per_page, "total_entries" => 60, "total_pages" => 2 }
           }
           response
         end

--- a/lib/fog/dnsimple/requests/dns/list_records.rb
+++ b/lib/fog/dnsimple/requests/dns/list_records.rb
@@ -2,32 +2,34 @@ module Fog
   module DNS
     class Dnsimple
       class Real
-        # Get the list of records for the specific zone.
+        # Get the paginated list of records for the specific zone.
         #
-        # ==== Parameters
-        # * zone_name<~String> - zone name
+        # @see https://developer.dnsimple.com/v2/zones/records/#list
+        # @see https://github.com/dnsimple/dnsimple-developer/tree/master/fixtures/v2/listZoneRecords
         #
-        # ==== Returns
-        # * response<~Excon::Response>:
-        #   * body<~Hash>:
-        #     * "data"<~Array>:
-        #       * <~Hash> The representation of the record.
-        def list_records(zone_name)
+        # @param  zone_name [String]
+        # @param  query [Hash]
+        # @return [Excon::Response]
+        def list_records(zone_name, query: {})
           request(
-            expects:  200,
-            method:   "GET",
-            path:     "/#{@dnsimple_account}/zones/#{zone_name}/records"
+            expects: 200,
+            method: "GET",
+            path: "/#{@dnsimple_account}/zones/#{zone_name}/records",
+            query: query
           )
         end
       end
 
       class Mock
-        def list_records(zone_name)
+        def list_records(zone_name, query: {})
+          page = query[:page] || 1
+          per_page = query[:per_page] || 30
+
           response = Excon::Response.new
           response.status = 200
           response.body = {
               "data" => Array(self.data[:records][zone_name]),
-              "pagination" => { "current_page" => 1, "per_page" => 30, "total_entries" => 60, "total_pages" => 2 }
+              "pagination" => { "current_page" => page, "per_page" => per_page, "total_entries" => 60, "total_pages" => 2 }
           }
           response
         end

--- a/test/requests/dns/dns_test.rb
+++ b/test/requests/dns/dns_test.rb
@@ -13,14 +13,13 @@ class Fog::DNS::Dnsimple::DnsTest < Minitest::Test
     @domain = nil
     @domain_count = 0
 
+
     ## Get current domain count
 
     response = Fog::DNS[:dnsimple].list_domains
-    if response.status == 200
-      @domain_count = response.body["data"].size
-    end
-
     assert_equal 200, response.status
+
+    @domain_count = response.body["data"].size
 
 
     ## Create domain
@@ -95,12 +94,20 @@ class Fog::DNS::Dnsimple::DnsTest < Minitest::Test
     ## List records
 
     response = Fog::DNS[:dnsimple].list_records(@domain["name"])
-
     assert_equal 200, response.status
 
     # list records returns all records for domain
     @records = response.body["data"]
     assert_equal 2, @records.reject { |record| record["system_record"] }.size
+
+
+    ## Pagination
+
+    response = Fog::DNS[:dnsimple].list_all_domains
+    assert_equal 200, response.status
+
+    response = Fog::DNS[:dnsimple].list_all_records(@domain["name"])
+    assert_equal 200, response.status
 
 
     # Delete records


### PR DESCRIPTION
The list_domains and list_records methods will continue to default to paginated lists. If you want the whole list you must use the dedicated methods.

list_domains and list_records now also accepts query parameters.

---

Closes #4
/cc @dturn
